### PR TITLE
include_block tag for render StreamField

### DIFF
--- a/wagtailcolumnblocks/templates/blocks/columnsblock.html
+++ b/wagtailcolumnblocks/templates/blocks/columnsblock.html
@@ -1,8 +1,10 @@
+{% load wagtailcore_tags %}
+
 <div class="row">
   {% for column, width in columns %}
     {# width is relative to a column grid width, e.g. 12 #}
     <div class="column col-{{ width }}">
-        {{ column }}
+      {% include_block column %}
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
{% include_block %} is allow forwarding context to a Block
If you use forms in the StreamField, then this change will solve a problem with csrf_token