### PR TITLE
Update blocks.py

### DIFF
--- a/wagtailcolumnblocks/blocks.py
+++ b/wagtailcolumnblocks/blocks.py
@@ -4,7 +4,7 @@ Block definitions for generic column blocks.
 
 from django import forms
 from django.apps import apps
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 from wagtail.core import blocks
 


### PR DESCRIPTION
django.contrib.staticfiles.templatetags.static() is deprecated since Django 2.1 in favor of django.templatetags.static.static().