### PR TITLE
Update columns.css

### DIFF
--- a/wagtailcolumnblocks/static/wagtailcolumnblocks/columns.css
+++ b/wagtailcolumnblocks/static/wagtailcolumnblocks/columns.css
@@ -1,62 +1,30 @@
-/* Patch nested streamfields */
-.sequence-member:hover,
-.sequence-container:hover {
-  /* From this */
-  /* To this */ }
-  .sequence-member:hover .sequence-controls,
-  .sequence-member:hover .stream-menu-closed,
-  .sequence-container:hover .sequence-controls,
-  .sequence-container:hover .stream-menu-closed {
-    opacity: 0;
-    visibility: hidden; }
-  .sequence-member:hover > .sequence-controls,
-  .sequence-member:hover > .stream-menu-closed,
-  .sequence-container:hover > .sequence-controls,
-  .sequence-container:hover > .stream-menu-closed {
-    opacity: 1;
-    visibility: visible; }
-
-li.sequence-member .columns-block.struct-block {
-  padding-top: 1em;
-  margin-left: -50px;
-  margin-right: -50px; }
-  li.sequence-member .columns-block.struct-block > .fields {
+.c-sf-block .columns-block.struct-block {
+  padding-top: 0;
+}
+  .c-sf-block .columns-block.struct-block > .fields {
     display: flex;
     flex-wrap: wrap;
     float: none;
-    width: 100%; }
-    li.sequence-member .columns-block.struct-block > .fields > li {
+    width: 100%; 
+  }
+    .c-sf-block .columns-block.struct-block > .fields > li {
       width: 100%;
       min-width: 400px;
-      flex: 1; }
-      li.sequence-member .columns-block.struct-block > .fields > li > label {
-        display: none;
+      flex: 1; 
+    }
+      .c-sf-block .columns-block.struct-block > .fields > li > label {
         color: #43b1b0;
-        font-weight: 400;
         text-transform: uppercase;
         width: 100%;
-        padding: 5px;
+        padding: 0 24px;
+        display: none;
         position: absolute;
-        top: -22px; }
-      li.sequence-member .columns-block.struct-block > .fields > li:hover > label {
+      }
+      .c-sf-block .columns-block.struct-block > .fields > li:hover > label {
         display: block; }
-      li.sequence-member .columns-block.struct-block > .fields > li > .sequence-container {
+      .c-sf-block .columns-block.struct-block > .fields > li > .c-sf-container {
         width: 100%;
         height: 100%;
         min-height: 50px; }
-        li.sequence-member .columns-block.struct-block > .fields > li > .sequence-container .sequence-member {
-          border-top: 1px solid transparent;
-          border-bottom: 1px solid transparent; }
-          li.sequence-member .columns-block.struct-block > .fields > li > .sequence-container .sequence-member > .sequence-member-inner {
-            padding-left: 50px;
-            padding-right: 50px; }
-          li.sequence-member .columns-block.struct-block > .fields > li > .sequence-container .sequence-member .stream-menu-inner {
-            margin-left: 1em;
-            margin-right: 1em; }
-          li.sequence-member .columns-block.struct-block > .fields > li > .sequence-container .sequence-member:hover {
+        .c-sf-block .columns-block.struct-block > .fields > li > .c-sf-container .c-sf-block:hover {
             border-color: #ccf1f1; }
-        li.sequence-member .columns-block.struct-block > .fields > li > .sequence-container .richtext {
-          border: 0;
-          padding: 0;
-          background-color: transparent;
-          max-width: 1024px; }


### PR DESCRIPTION
After the last major Streamfield makeover, class names got changed. This updated CSS works for Wagtail > v.2.7 (I think, only tested with 2.9 today). I removed most hover-hide-effects for now as these got confusing applied to the new title bars of the blocks. Hope this helps.