### PR TITLE
Compatibility with wagtail 2.13

### DIFF
--- a/wagtailcolumnblocks/static/wagtailcolumnblocks/columns.css
+++ b/wagtailcolumnblocks/static/wagtailcolumnblocks/columns.css
@@ -29,7 +29,6 @@ li.sequence-member .columns-block.struct-block {
     width: 100%; }
     li.sequence-member .columns-block.struct-block > .fields > li {
       width: 100%;
-      min-width: 400px;
       flex: 1; }
       li.sequence-member .columns-block.struct-block > .fields > li > label {
         display: none;
@@ -76,7 +75,6 @@ li.sequence-member .columns-block.struct-block {
   }
     .c-sf-block .columns-block.struct-block > .fields > li {
       width: 100%;
-      min-width: 400px;
       flex: 1; 
     }
       .c-sf-block .columns-block.struct-block > .fields > li > label {

--- a/wagtailcolumnblocks/templates/block_forms/columnsblock.html
+++ b/wagtailcolumnblocks/templates/block_forms/columnsblock.html
@@ -1,17 +1,26 @@
+{% load wagtailadmin_tags  %}
+
 <div class="{{ classname }}">
     {% if help_text %}
-        <div class="object-help help">{{ help_text }}</div>
+        <span>
+            <div class="help">
+                {% icon name="help" class_name="default" %}
+                {{ help_text }}
+            </div>
+        </span>
     {% endif %}
 
     <ul class="fields">
         {% for child, ratio in columns %}
-            <li{% if child.block.required %} class="required"{% endif %}
-                                             style="flex: {{ ratio }};">
+            <li class="field {% if child.block.required %}required{% endif %}"
+                data-contentpath="{{ child.block.name }}"
+                style="flex: {{ ratio }};">
                 {% if child.block.label %}
-                    <label{% if child.id_for_label %} for="{{ child.id_for_label }}"{% endif %}>{{ child.block.label }}</label>
+                    <label class="field__label" {% if child.id_for_label %} for="{{ child.id_for_label }}"{% endif %}>{{ child.block.label }}</label>
                 {% endif %}
                 {{ child.render_form }}
             </li>
         {% endfor %}
     </ul>
 </div>
+


### PR DESCRIPTION
Hello,

I found the PR #9  to be incomplete, so I added few things here, it should fix aswell Issue #8. I followed the wagtail documentation : https://docs.wagtail.io/en/latest/advanced_topics/customisation/streamfield_blocks.html#custom-streamfield-blocks.

Here are my observations about the 2.13 : 
- When upgrading to wagtail 2.13, frontend behave differently. It seems that the previous trick ` super().__init__([('column_%i' % index, childblocks)` does not work good enough because the generated html for the columns has the same ID for both blocks (also the same label), thus the frontend is confused and acts weirdly on things like imagechoser or richtext editor. To fix that, I pass a class for the childblocks instead of an instance, and then instanciate it for each "column". 
- The media property does not seem to be the way to pass custom css to the admin anymore, instead the hook `insert_editor_css` should be used. When I use media property, I dont get the css on the admin with Wagtail 2.13.

The main problem with my PR is that it introduces an API breaking change with previous version, since you have to pass a class instead of an instance to the constructor (`CommonBlocks` vs `CommonBlocks()`). Maybe someone has a better idea ? Something like `copy()` would do the trick but there is no such function on blocks.

