### PR TITLE
class_name attribute on columnsblock is no longer supported

### DIFF
--- a/wagtailcolumnblocks/templates/block_forms/columnsblock.html
+++ b/wagtailcolumnblocks/templates/block_forms/columnsblock.html
@@ -4,7 +4,7 @@
     {% if help_text %}
         <span>
             <div class="help">
-                {% icon name="help" class_name="default" %}
+                {% icon name="help" classname="default" %}
                 {{ help_text }}
             </div>
         </span>


### PR DESCRIPTION
See https://github.com/wagtail/wagtail/commit/df44cf7998ae537317a8b8ada77871d18d31f682